### PR TITLE
DateInRegion 모델 생성

### DIFF
--- a/Project/PayRoad.xcodeproj/project.pbxproj
+++ b/Project/PayRoad.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		A74507F61F39B2C700DFFADF /* CurrencyEditorViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A74507F41F39B2C700DFFADF /* CurrencyEditorViewController.storyboard */; };
 		A74507FB1F3A4EBB00DFFADF /* ExtensionUITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74507FA1F3A4EBB00DFFADF /* ExtensionUITextField.swift */; };
 		A74507FD1F3ADD5600DFFADF /* ExtensionUIStoryboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74507FC1F3ADD5600DFFADF /* ExtensionUIStoryboard.swift */; };
+		B380C12F1F3D3109003857A2 /* DateInRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B380C12E1F3D3109003857A2 /* DateInRegion.swift */; };
 		B3FE8ACD1F3AD50A00A4A6C4 /* CurrencySelectTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE8ACC1F3AD50A00A4A6C4 /* CurrencySelectTableViewController.swift */; };
 		B3FE8ACF1F3AD58C00A4A6C4 /* CurrencySelectTableViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3FE8ACE1F3AD58C00A4A6C4 /* CurrencySelectTableViewController.storyboard */; };
 		E5B26E581F3AC8CF00D63AAB /* RealmHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B26E571F3AC8CF00D63AAB /* RealmHelper.swift */; };
@@ -60,6 +61,7 @@
 		A74507F51F39B2C700DFFADF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/CurrencyEditorViewController.storyboard; sourceTree = "<group>"; };
 		A74507FA1F3A4EBB00DFFADF /* ExtensionUITextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionUITextField.swift; sourceTree = "<group>"; };
 		A74507FC1F3ADD5600DFFADF /* ExtensionUIStoryboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionUIStoryboard.swift; sourceTree = "<group>"; };
+		B380C12E1F3D3109003857A2 /* DateInRegion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateInRegion.swift; sourceTree = "<group>"; };
 		B3FE8ACC1F3AD50A00A4A6C4 /* CurrencySelectTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrencySelectTableViewController.swift; sourceTree = "<group>"; };
 		B3FE8ACE1F3AD58C00A4A6C4 /* CurrencySelectTableViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = CurrencySelectTableViewController.storyboard; sourceTree = "<group>"; };
 		E5B26E571F3AC8CF00D63AAB /* RealmHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmHelper.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 				A74507D91F39878B00DFFADF /* Travel.swift */,
 				A74507D71F3984AB00DFFADF /* Transaction.swift */,
 				A74507DF1F398BB800DFFADF /* Currency.swift */,
+				B380C12E1F3D3109003857A2 /* DateInRegion.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -343,6 +346,7 @@
 				A74507FD1F3ADD5600DFFADF /* ExtensionUIStoryboard.swift in Sources */,
 				A74507E01F398BB800DFFADF /* Currency.swift in Sources */,
 				A74507D81F3984AB00DFFADF /* Transaction.swift in Sources */,
+				B380C12F1F3D3109003857A2 /* DateInRegion.swift in Sources */,
 				B3FE8ACD1F3AD50A00A4A6C4 /* CurrencySelectTableViewController.swift in Sources */,
 				E5B26E581F3AC8CF00D63AAB /* RealmHelper.swift in Sources */,
 			);

--- a/Project/PayRoad/DateInRegion.swift
+++ b/Project/PayRoad/DateInRegion.swift
@@ -1,0 +1,50 @@
+//
+//  DateInRegion.swift
+//  PayRoad
+//
+//  Created by 손동찬 on 2017. 8. 11..
+//  Copyright © 2017년 REFUEL. All rights reserved.
+//
+
+import RealmSwift
+
+enum DateFormat {
+    case section
+    case detail
+}
+
+class DateInRegion: Object {
+    
+    dynamic var date = Date()
+    dynamic var _timeZone: String = ""
+    
+    var timeZone: TimeZone {
+        get { return TimeZone(identifier: _timeZone) ?? .current }
+        set { _timeZone = timeZone.identifier }
+    }
+
+    override static func ignoredProperties() -> [String] {
+        return ["timeZone"]
+    }
+}
+
+// MARK: DateInRegion Formatter
+
+extension DateInRegion {
+    
+    public func string(format: DateFormat) -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = self.timeZone
+        
+        switch format {
+        case .section:
+            formatter.dateStyle = .long
+            formatter.timeStyle = .none
+        case .detail:
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .medium
+        }
+        
+        return formatter.string(from: date)
+    }
+}

--- a/Project/PayRoad/Transaction.swift
+++ b/Project/PayRoad/Transaction.swift
@@ -14,17 +14,7 @@ class Transaction: Object {
     dynamic var amount: Double = 0.0
     dynamic var currency: Currency?
     
-    // Date: Date
-    dynamic var date = Date()
-    dynamic var timeZone: String = ""
-    
-    // Date: Int
-    dynamic var year = 0
-    dynamic var month = 0
-    dynamic var day = 0
-    dynamic var hour = 0
-    dynamic var minute = 0
-    dynamic var second = 0
+    dynamic var dateInRegion: DateInRegion?
     
     dynamic var content: String = ""
     

--- a/Project/PayRoad/TransactionEditorViewController.swift
+++ b/Project/PayRoad/TransactionEditorViewController.swift
@@ -66,17 +66,11 @@ class TransactionEditorViewController: UIViewController {
         transaction.amount = amount
         transaction.currency = currency
         
-        let date = Date()
-        transaction.date = date
+        let dateInRegion = DateInRegion()
+        dateInRegion.date = Date()
+        dateInRegion.timeZone = TimeZone.current
+        transaction.dateInRegion = dateInRegion
         
-        let calendar = Calendar.current
-        transaction.year = calendar.component(.year, from: date)
-        transaction.month = calendar.component(.month, from: date)
-        transaction.day = calendar.component(.day, from: date)
-        transaction.hour = calendar.component(.hour, from: date)
-        transaction.minute = calendar.component(.minute, from: date)
-        transaction.second = calendar.component(.second, from: date)
-
         do {
             try realm.write {
                 travel.transactions.append(transaction)

--- a/Project/PayRoad/TransactionTableViewController.swift
+++ b/Project/PayRoad/TransactionTableViewController.swift
@@ -77,8 +77,14 @@ class TransactionTableViewController: UIViewController {
         dateList = [String]()
         
         for transaction in travel.transactions {
-            let dateString = DateUtil.dateFormatter.string(from: transaction.date)
             
+            guard let dateInRegion = transaction.dateInRegion else {
+                return
+            }
+            
+            //let dateString = DateUtil.dateFormatter.string(from: dateInRegion.date)
+            let dateString = dateInRegion.string(format: .section)
+                
             if dateDictionary[dateString] == nil {
                 dateDictionary[dateString] = []
             }


### PR DESCRIPTION
- Transaction에서 date와 timeZone을 DateInRegion 모델로 분리
- DateInRegion의 string 메소드를 추가하여 formatter 기능을 구현
- TransactionTableViewController에서 dateString을 구할 때 위의 메소드를 활용하는 것으로 변경