### PR TITLE
transaction 이미지 추가 기능 구현.

### DIFF
--- a/Project/PayRoad.xcodeproj/project.pbxproj
+++ b/Project/PayRoad.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		B3FE8ACF1F3AD58C00A4A6C4 /* CurrencySelectTableViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3FE8ACE1F3AD58C00A4A6C4 /* CurrencySelectTableViewController.storyboard */; };
 		E5B26E581F3AC8CF00D63AAB /* RealmHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B26E571F3AC8CF00D63AAB /* RealmHelper.swift */; };
 		E5B26E5D1F3C11A100D63AAB /* DateUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B26E5C1F3C11A100D63AAB /* DateUtil.swift */; };
+		E5EA601B1F3FD4AC0077B39D /* UIImageEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5EA601A1F3FD4AC0077B39D /* UIImageEncoding.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -74,6 +75,7 @@
 		B3FE8ACE1F3AD58C00A4A6C4 /* CurrencySelectTableViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = CurrencySelectTableViewController.storyboard; sourceTree = "<group>"; };
 		E5B26E571F3AC8CF00D63AAB /* RealmHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmHelper.swift; sourceTree = "<group>"; };
 		E5B26E5C1F3C11A100D63AAB /* DateUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateUtil.swift; sourceTree = "<group>"; };
+		E5EA601A1F3FD4AC0077B39D /* UIImageEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageEncoding.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,6 +197,7 @@
 				A74507FC1F3ADD5600DFFADF /* ExtensionUIStoryboard.swift */,
 				E5B26E5C1F3C11A100D63AAB /* DateUtil.swift */,
 				A7EBD22E1F3ED8790057E844 /* Color.swift */,
+				E5EA601A1F3FD4AC0077B39D /* UIImageEncoding.swift */,
 			);
 			name = Extension;
 			sourceTree = "<group>";
@@ -354,6 +357,7 @@
 				E5B26E5D1F3C11A100D63AAB /* DateUtil.swift in Sources */,
 				A7EBD2311F3ED8BE0057E844 /* ExtensionUIColor.swift in Sources */,
 				A74507E21F398E2200DFFADF /* CurrencyEditorViewController.swift in Sources */,
+				E5EA601B1F3FD4AC0077B39D /* UIImageEncoding.swift in Sources */,
 				A74507E91F39966600DFFADF /* TransactionEditorViewController.swift in Sources */,
 				A7EBD2331F3EDAE90057E844 /* DateSelectCollectionView.swift in Sources */,
 				A74507FB1F3A4EBB00DFFADF /* ExtensionUITextField.swift in Sources */,

--- a/Project/PayRoad/Info.plist
+++ b/Project/PayRoad/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string></string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Project/PayRoad/Transaction.swift
+++ b/Project/PayRoad/Transaction.swift
@@ -13,6 +13,7 @@ class Transaction: Object {
     dynamic var name = ""
     dynamic var amount: Double = 0.0
     dynamic var currency: Currency?
+    dynamic var imageData: Data?
     
     dynamic var dateInRegion: DateInRegion?
     

--- a/Project/PayRoad/TransactionEditorViewController.storyboard
+++ b/Project/PayRoad/TransactionEditorViewController.storyboard
@@ -22,47 +22,56 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="항목명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ke4-tf-QQn">
-                                <rect key="frame" x="107" y="133" width="45" height="21"/>
+                                <rect key="frame" x="99" y="119" width="45" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="통화" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fRY-eU-A2k">
-                                <rect key="frame" x="107" y="209" width="30" height="21"/>
+                                <rect key="frame" x="99" y="195" width="30" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oZS-VG-LuT">
-                                <rect key="frame" x="187" y="128" width="97" height="30"/>
+                                <rect key="frame" x="179" y="114" width="97" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cBu-pu-8GF">
-                                <rect key="frame" x="187" y="166" width="97" height="30"/>
+                                <rect key="frame" x="179" y="152" width="97" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="DBv-UJ-QPz">
-                                <rect key="frame" x="187" y="204" width="97" height="30"/>
+                                <rect key="frame" x="179" y="190" width="97" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="금액" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2QR-mo-tTZ">
-                                <rect key="frame" x="107" y="166" width="30" height="21"/>
+                                <rect key="frame" x="99" y="152" width="30" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <imageView contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="elh-QA-Ris">
+                                <rect key="frame" x="16" y="251" width="343" height="165"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <gestureRecognizers/>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="BhK-5O-cLI" appends="YES" id="9nw-Mf-utN"/>
+                                </connections>
+                            </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
@@ -78,11 +87,17 @@
                         <outlet property="amountTextField" destination="cBu-pu-8GF" id="kJP-Bp-ioi"/>
                         <outlet property="currencyTextField" destination="DBv-UJ-QPz" id="AIU-R2-ElT"/>
                         <outlet property="nameTextField" destination="oZS-VG-LuT" id="Tew-e4-SxZ"/>
+                        <outlet property="transactionImageView" destination="elh-QA-Ris" id="2qu-EC-ocC"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="a8b-0h-UTf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="BhK-5O-cLI">
+                    <connections>
+                        <action selector="selectImageFromPhotoLibrary:" destination="8cC-mM-Tm3" id="1UE-97-e3Z"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="2594" y="170"/>
+            <point key="canvasLocation" x="2592.8000000000002" y="169.56521739130437"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="92j-sb-yD0">

--- a/Project/PayRoad/TransactionEditorViewController.swift
+++ b/Project/PayRoad/TransactionEditorViewController.swift
@@ -35,6 +35,7 @@ class TransactionEditorViewController: UIViewController {
     @IBOutlet weak var nameTextField: UITextField!
     @IBOutlet weak var amountTextField: UITextField!
     @IBOutlet weak var currencyTextField: UITextField!
+    @IBOutlet weak var transactionImageView: UIImageView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -65,6 +66,7 @@ class TransactionEditorViewController: UIViewController {
     @IBAction func cancelButtonDidTap(_ sender: Any) {
         dismiss(animated: true, completion: nil)
     }
+
 }
 
 extension TransactionEditorViewController: UIPickerViewDelegate, UIPickerViewDataSource {
@@ -99,6 +101,11 @@ extension TransactionEditorViewController {
             nameTextField?.text = originTransaction.name
             amountTextField?.text = String(originTransaction.amount)
             currencyTextField?.text = originTransaction.currency?.code
+            
+            if let imageData = originTransaction.imageData,
+                let image = UIImage(data: imageData) {
+                transactionImageView.image = image
+            }
             
             let editBarButtonItem: UIBarButtonItem
             let selector = #selector(editButtonDidTap)
@@ -144,6 +151,7 @@ extension TransactionEditorViewController {
                 originTransaction.name = transaction.name
                 originTransaction.amount = transaction.amount
                 originTransaction.currency = transaction.currency
+                originTransaction.imageData = transaction.imageData
                 print("트랜젝션 수정")
             }
         } catch {
@@ -164,5 +172,35 @@ extension TransactionEditorViewController {
         transaction.name = name
         transaction.amount = amount
         transaction.currency = currency
+        transaction.imageData = transactionImageView.image?.data()
+    }
+}
+
+extension TransactionEditorViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
+        guard let selectedImage = info[UIImagePickerControllerOriginalImage] as? UIImage else {
+            fatalError("Expected a dictionary containing an image, but was provided the following: \(info)")
+        }
+        
+        // Set photoImageView to display the selected image.
+        transactionImageView.image = selectedImage
+        
+        // Dismiss the picker.
+        dismiss(animated: true, completion: nil)
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    @IBAction func selectImageFromPhotoLibrary(_ sender: UITapGestureRecognizer) {
+        self.view.endEditing(true)
+        let imagePickerController = UIImagePickerController()
+        
+        imagePickerController.sourceType = .photoLibrary
+        
+        imagePickerController.delegate = self
+        present(imagePickerController, animated: true, completion: nil)
     }
 }

--- a/Project/PayRoad/UIImageEncoding.swift
+++ b/Project/PayRoad/UIImageEncoding.swift
@@ -1,0 +1,32 @@
+//
+//  UIImageEncoding.swift
+//  PayRoad
+//
+//  Created by Yoo Seok Kim on 2017. 8. 13..
+//  Copyright © 2017년 REFUEL. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIImage {
+    func resizeImage(_ image: UIImage, size: CGSize) -> UIImage {
+        UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+        image.draw(in: CGRect(origin: CGPoint.zero, size: size))
+        let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return resizedImage!
+    }
+    
+    func data() -> Data {
+        var imageData = UIImagePNGRepresentation(self)
+        // Resize the image if it exceeds the 2MB limit
+        if (imageData?.count)! > 2097152 {
+            let oldSize = self.size
+            let newSize = CGSize(width: 800, height: oldSize.height / oldSize.width * 800)
+            let newImage = self.resizeImage(self, size: newSize)
+            imageData = UIImageJPEGRepresentation(newImage, 0.7)
+        }
+        return imageData!
+    }
+}


### PR DESCRIPTION
close #36 
TransactionEditorViewController '스토리보드' 수정
transaction 모델에 imageData 추가. (모델 수정됨)
UIImage -> Data를 위한 extension 구현
트랜잭션 생성/수정 시 이미지 첨부 가능