### PR TITLE
지출 카테고리 자동 생성, Currency 모델 일부 변경

### DIFF
--- a/Project/PayRoad.xcodeproj/project.pbxproj
+++ b/Project/PayRoad.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		A7EBD2311F3ED8BE0057E844 /* ExtensionUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EBD2301F3ED8BE0057E844 /* ExtensionUIColor.swift */; };
 		B380C12F1F3D3109003857A2 /* DateInRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B380C12E1F3D3109003857A2 /* DateInRegion.swift */; };
 		B38735E21F418E51000DC81C /* YMD.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38735E11F418E51000DC81C /* YMD.swift */; };
+		B38735E81F45C5CE000DC81C /* RealmInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38735E71F45C5CE000DC81C /* RealmInitializer.swift */; };
 		B3FE8ACD1F3AD50A00A4A6C4 /* CurrencySelectTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE8ACC1F3AD50A00A4A6C4 /* CurrencySelectTableViewController.swift */; };
 		B3FE8ACF1F3AD58C00A4A6C4 /* CurrencySelectTableViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3FE8ACE1F3AD58C00A4A6C4 /* CurrencySelectTableViewController.storyboard */; };
 		E50D13AA1F41C56E00BD36CC /* FileUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50D13A91F41C56E00BD36CC /* FileUtil.swift */; };
@@ -95,6 +96,7 @@
 		A7EBD2301F3ED8BE0057E844 /* ExtensionUIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionUIColor.swift; sourceTree = "<group>"; };
 		B380C12E1F3D3109003857A2 /* DateInRegion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateInRegion.swift; sourceTree = "<group>"; };
 		B38735E11F418E51000DC81C /* YMD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YMD.swift; sourceTree = "<group>"; };
+		B38735E71F45C5CE000DC81C /* RealmInitializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmInitializer.swift; sourceTree = "<group>"; };
 		B3FE8ACC1F3AD50A00A4A6C4 /* CurrencySelectTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrencySelectTableViewController.swift; sourceTree = "<group>"; };
 		B3FE8ACE1F3AD58C00A4A6C4 /* CurrencySelectTableViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = CurrencySelectTableViewController.storyboard; sourceTree = "<group>"; };
 		E50D13A91F41C56E00BD36CC /* FileUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileUtil.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 			isa = PBXGroup;
 			children = (
 				A74507FC1F3ADD5600DFFADF /* ExtensionUIStoryboard.swift */,
+				B38735E71F45C5CE000DC81C /* RealmInitializer.swift */,
 				A7B4F6DF1F436E900049D812 /* ExtensionUIView.swift */,
 				E5EA601A1F3FD4AC0077B39D /* ExtensionUIImage.swift */,
 				A74507FA1F3A4EBB00DFFADF /* ExtensionUITextField.swift */,
@@ -408,6 +411,7 @@
 				A7B4F6EE1F4439C40049D812 /* CustomLabel.swift in Sources */,
 				A7B4F6E81F43A30C0049D812 /* UnableInputTextField.swift in Sources */,
 				A74507BD1F3976C300DFFADF /* TravelTableViewController.swift in Sources */,
+				B38735E81F45C5CE000DC81C /* RealmInitializer.swift in Sources */,
 				A74507E41F39905900DFFADF /* CurrencyTableViewController.swift in Sources */,
 				A7B4F6E41F437A1F0049D812 /* CategoryCollectionViewCell.swift in Sources */,
 				A74507BB1F3976C300DFFADF /* AppDelegate.swift in Sources */,

--- a/Project/PayRoad/AppDelegate.swift
+++ b/Project/PayRoad/AppDelegate.swift
@@ -15,6 +15,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         print(Realm.Configuration.defaultConfiguration.fileURL!)
+        
+        RealmInitializer.initializeCategories()
 //        application.statusBarStyle = .lightContent
         
         //UINavigationBar customize

--- a/Project/PayRoad/Category.swift
+++ b/Project/PayRoad/Category.swift
@@ -5,6 +5,7 @@
 //  Created by Yoo Seok Kim on 2017. 8. 15..
 //  Copyright © 2017년 REFUEL. All rights reserved.
 //
+
 import Foundation
 import RealmSwift
 
@@ -12,9 +13,11 @@ class Category: Object {
     dynamic var id = UUID().uuidString
     dynamic var name = ""
     dynamic var assetName = ""
+
+    override static func primaryKey() -> String? {
+        return "id"
+    }
 }
-
-
 
 //Category Class를 Local 모델로 갖고 Transaction은 Category Index를 가지는게 어떤지
 class CategoryTEST {

--- a/Project/PayRoad/Currency.swift
+++ b/Project/PayRoad/Currency.swift
@@ -9,7 +9,7 @@
 import RealmSwift
 
 class Currency: Object {
-    dynamic var id = UUID().uuidString
+    dynamic var id = ""
     dynamic var code = ""
     dynamic var rate: Double = 1.0
     dynamic var budget: Double = 0.0

--- a/Project/PayRoad/CurrencyEditorViewController.swift
+++ b/Project/PayRoad/CurrencyEditorViewController.swift
@@ -192,6 +192,7 @@ extension CurrencyEditorViewController {
         }
         
         let currency = Currency()
+        currency.id = travel.id + "-" + editedCurrency.code
         currency.code = editedCurrency.code
         currency.rate = editedCurrency.rate
         currency.budget = editedCurrency.budget
@@ -214,7 +215,6 @@ extension CurrencyEditorViewController {
         
         do {
             try realm.write {
-                originCurrency.code = editedCurrency.code
                 originCurrency.rate = editedCurrency.rate
                 originCurrency.budget = editedCurrency.budget
                 print("통화 수정")

--- a/Project/PayRoad/RealmInitializer.swift
+++ b/Project/PayRoad/RealmInitializer.swift
@@ -1,0 +1,67 @@
+//
+//  AppInitial.swift
+//  PayRoad
+//
+//  Created by 손동찬 on 2017. 8. 17..
+//  Copyright © 2017년 REFUEL. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+class RealmInitializer {
+
+    private static let realm = try! Realm()
+    
+    static func initializeCategories() {
+        
+        let resultsCategory = realm.objects(Category.self)
+        
+        if resultsCategory.count == 0 {
+            
+            var categories = [Category]()
+            
+            let category1 = Category()
+            category1.id = "category-food"
+            category1.name = "식비"
+            category1.assetName = "Category_Food"
+            categories.append(category1)
+            
+            let category2 = Category()
+            category2.id = "category-shopping"
+            category2.name = "쇼핑"
+            category2.assetName = "Category_Shopping"
+            categories.append(category2)
+            
+            let category3 = Category()
+            category3.id = "category-tour"
+            category3.name = "관광"
+            category3.assetName = "Category_Tour"
+            categories.append(category3)
+            
+            let category4 = Category()
+            category4.id = "category-transport"
+            category4.name = "교통"
+            category4.assetName = "Category_Transport"
+            categories.append(category4)
+            
+            let category5 = Category()
+            category5.id = "category-lodge"
+            category5.name = "숙박"
+            category5.assetName = "Category_Lodge"
+            categories.append(category5)
+            
+            let category6 = Category()
+            category6.id = "category-etc"
+            category6.name = "기타"
+            category6.assetName = "Category_Etc"
+            categories.append(category6)
+            
+            for category in categories {
+                try? realm.write {
+                    realm.add(category)
+                }
+            }
+        }
+    }
+}

--- a/Project/PayRoad/TravelEditorViewController.swift
+++ b/Project/PayRoad/TravelEditorViewController.swift
@@ -163,6 +163,7 @@ extension TravelEditorViewController {
         
         if let currencyCode = Locale.current.currencyCode {
             let currency = Currency()
+            currency.id = travel.id + "-" + currencyCode
             currency.code = currencyCode
             currency.rate = 1.0
             travel.currencies.append(currency)


### PR DESCRIPTION
- realm에 저장된 카테고리가 없으면 6개의 기본 카테고리를 자동 생성
- 추후 Category.id를 이용하여 Localizaion을 할 필요가 있음
- Currency 모델의 id를 임의의 UUID를 부여하는 방식에서 Travel.id-Currency.Code로 직접 지정