### PR TITLE
여행 추가시 예산 설정 방식 변경

### DIFF
--- a/Project/PayRoad/Base.lproj/CurrencyTableViewController.storyboard
+++ b/Project/PayRoad/Base.lproj/CurrencyTableViewController.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="9DK-q4-WR7">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="9DK-q4-WR7">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/Project/PayRoad/Base.lproj/TravelEditorViewController.storyboard
+++ b/Project/PayRoad/Base.lproj/TravelEditorViewController.storyboard
@@ -64,24 +64,6 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="예산" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oeY-Ng-13e">
-                                        <rect key="frame" x="38" y="398" width="45" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" name="AppleSDGothicNeo-Light" family="Apple SD Gothic Neo" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="phd-kM-iy2">
-                                        <rect key="frame" x="38" y="427" width="307" height="37"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" red="0.4823529411764706" green="0.66666666666666663" blue="0.94509803921568625" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <state key="normal" title="예산 설정">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="setupCurrencyBudgetButtonDidTap:" destination="zEU-DO-42O" eventType="touchUpInside" id="kSk-VN-kpb"/>
-                                        </connections>
-                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y1G-m5-h6f">
                                         <rect key="frame" x="38" y="472" width="307" height="37"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -113,7 +95,6 @@
                         <outlet property="backgroundScrollView" destination="F10-3l-pnX" id="JON-F4-SgZ"/>
                         <outlet property="deleteTravelButton" destination="Y1G-m5-h6f" id="2zX-cm-48R"/>
                         <outlet property="endDateTextField" destination="eO1-9n-Yp5" id="r9Y-9Z-Oya"/>
-                        <outlet property="setupCurrencyBudgetButton" destination="phd-kM-iy2" id="55A-oo-G9v"/>
                         <outlet property="startDateTextField" destination="LEL-ca-RaG" id="baj-OA-Xk2"/>
                         <outlet property="titleTextField" destination="4lO-gS-iMJ" id="DhK-Nm-kVQ"/>
                         <outlet property="travelPreview" destination="RNB-pU-ajv" id="89w-eu-rqY"/>

--- a/Project/PayRoad/CurrencyTableViewController.swift
+++ b/Project/PayRoad/CurrencyTableViewController.swift
@@ -12,6 +12,8 @@ import RealmSwift
 
 class CurrencyTableViewController: UIViewController {
     
+    let realm = try! Realm()
+    
     var travel: Travel!
     var notificationToken: NotificationToken? = nil
     
@@ -19,6 +21,18 @@ class CurrencyTableViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        if travel.currencies.count == 0 {
+            try? realm.write {
+                if let currencyCode = Locale.current.currencyCode {
+                    let currency = Currency()
+                    currency.id = travel.id + "-" + currencyCode
+                    currency.code = currencyCode
+                    currency.rate = 1.0
+                    travel.currencies.append(currency)
+                }
+            }
+        }
         
         tableView.delegate = self
         tableView.dataSource = self

--- a/Project/PayRoad/TransactionTableViewController.swift
+++ b/Project/PayRoad/TransactionTableViewController.swift
@@ -21,6 +21,7 @@ class TransactionTableViewController: UIViewController {
 
     var transactionsNotificationToken: NotificationToken? = nil
     var travelNotificationToken: NotificationToken? = nil
+    var currencyNotificationToken: NotificationToken? = nil
     
     var travelPeriodDates = [YMD]()
     var dateDictionary = [YMD: [Transaction]]()
@@ -64,6 +65,15 @@ class TransactionTableViewController: UIViewController {
         window.addSubview(sideBar)
 
         title = travel.name
+        
+        if travel.currencies.count == 0 {
+            let currencyTableViewController = UIStoryboard.loadViewController(from: .CurrencyTableView, ID: "CurrencyTableViewController") as! CurrencyTableViewController
+            let navigationController = UINavigationController(rootViewController: currencyTableViewController)
+            currencyTableViewController.travel = self.travel
+            
+            self.present(navigationController, animated: true, completion: nil)
+        }
+        
         sortedTransactions = travel.transactions.sorted(byKeyPath: "dateInRegion.date", ascending: false)
         
         tableView.delegate = self
@@ -107,6 +117,12 @@ class TransactionTableViewController: UIViewController {
             self?.title = self?.travel.name
             self?.extractDatePeriod()
             self?.collectionView.reloadData()
+        }
+        
+        currencyNotificationToken = travel.currencies.addNotificationBlock { [weak self] (changes: RealmCollectionChange) in
+            self?.initDataStructures()
+            self?.filterTransaction(selected: self?.currentSelectedDate)
+            self?.displayTotalSpendingCurrency()
         }
         
         NotificationCenter.default.addObserver(self, selector: #selector(stopNotificationToken), name: NSNotification.Name(rawValue: "stopTravelNotification"), object: nil)
@@ -285,6 +301,11 @@ class TransactionTableViewController: UIViewController {
     }
     
     func displayTotalSpendingCurrency() {
+        
+        if travel.currencies.count == 0 {
+            return
+        }
+        
         if totalSpendingIndex >= travel.currencies.count {
             totalSpendingIndex = 0
         }

--- a/Project/PayRoad/TravelEditorViewController.swift
+++ b/Project/PayRoad/TravelEditorViewController.swift
@@ -29,14 +29,12 @@ class TravelEditorViewController: UIViewController {
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var startDateTextField: UITextField!
     @IBOutlet weak var endDateTextField: UITextField!
-    @IBOutlet weak var setupCurrencyBudgetButton: UIButton!
     @IBOutlet weak var travelPreview: TravelView!
     @IBOutlet weak var deleteTravelButton: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupCurrencyBudgetButton.layer.cornerRadius = setupCurrencyBudgetButton.frame.height / 5
         deleteTravelButton.layer.cornerRadius = deleteTravelButton.frame.height / 5
 
         startDateTextField.inputDatePicker(mode: .date, date: travel.startDateInRegion?.date)
@@ -128,17 +126,17 @@ extension TravelEditorViewController {
                 travelPreview.backgroundImage.image = defaultBackgroundBGArray[Int(arc4random_uniform(UInt32(defaultBackgroundBGArray.count)))]
                 isModifyPhoto = true
                 
-                //TODO: 에러 해결해야 할 것
-                try? realm.write {
-                    if let currencyCode = Locale.current.currencyCode {
-                        let currency = Currency()
-                        currency.id = travel.id + "-" + currencyCode
-                        currency.code = currencyCode
-                        currency.rate = 1.0
-                        travel.currencies.append(currency)
-                    }
-                }
-                
+//                //TODO: 에러 해결해야 할 것
+//                try? realm.write {
+//                    if let currencyCode = Locale.current.currencyCode {
+//                        let currency = Currency()
+//                        currency.id = travel.id + "-" + currencyCode
+//                        currency.code = currencyCode
+//                        currency.rate = 1.0
+//                        travel.currencies.append(currency)
+//                    }
+//                }
+            
             case .edit:
                 self.navigationItem.title = self.travel.name
                 


### PR DESCRIPTION
- 여행을 등록할 때는 여행에 대한 정보만 입력하고 새 여행을 생성할 수 있도록 변경, 예산 설정 삭제
- 최초로 여행에 대한 접근을 할 때 통화 설정 페이지가 일회성으로 나오는 것으로 변경