### PR TITLE
환율 API 변경 및 관련된 부분 일부 수정

### DIFF
--- a/Project/PayRoad/Base.lproj/CurrencyEditorViewController.storyboard
+++ b/Project/PayRoad/Base.lproj/CurrencyEditorViewController.storyboard
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rJ0-Uc-ksM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rJ0-Uc-ksM">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--새 통화-->
+        <!--새 통화 및 예산-->
         <scene sceneID="GGL-dR-Lmg">
             <objects>
                 <viewController id="F8w-PZ-Zlp" customClass="CurrencyEditorViewController" customModule="PayRoad" customModuleProvider="target" sceneMemberID="viewController">
@@ -128,7 +128,7 @@
                             <outletCollection property="gestureRecognizers" destination="Pye-3H-sex" appends="YES" id="hy0-Db-1Wb"/>
                         </connections>
                     </view>
-                    <navigationItem key="navigationItem" title="새 통화" id="ifX-ax-57W">
+                    <navigationItem key="navigationItem" title="새 통화 및 예산" id="ifX-ax-57W">
                         <barButtonItem key="leftBarButtonItem" image="Icon_Cancel" id="b2o-ZQ-5vz">
                             <connections>
                                 <action selector="cancelButtonDidTap:" destination="F8w-PZ-Zlp" id="hJl-YA-dVZ"/>

--- a/Project/PayRoad/Base.lproj/CurrencyTableViewController.storyboard
+++ b/Project/PayRoad/Base.lproj/CurrencyTableViewController.storyboard
@@ -10,7 +10,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--통화 관리-->
+        <!--통화 및 예산-->
         <scene sceneID="k3e-6o-atd">
             <objects>
                 <viewController storyboardIdentifier="CurrencyTableViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="HR1-Bc-H6Q" customClass="CurrencyTableViewController" customModule="PayRoad" customModuleProvider="target" sceneMemberID="viewController">
@@ -96,7 +96,7 @@
                             <constraint firstItem="3Iz-aw-aN6" firstAttribute="top" secondItem="xc1-hD-3Wv" secondAttribute="top" id="t3m-Cd-vyu"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="통화 관리" id="YRp-bv-Ojc">
+                    <navigationItem key="navigationItem" title="통화 및 예산" id="YRp-bv-Ojc">
                         <barButtonItem key="leftBarButtonItem" image="Icon_Cancel" id="qn5-hy-xsu">
                             <connections>
                                 <action selector="cancelButtonDidTap:" destination="HR1-Bc-H6Q" id="psJ-5D-M4O"/>

--- a/Project/PayRoad/CurrencyEditorViewController.swift
+++ b/Project/PayRoad/CurrencyEditorViewController.swift
@@ -80,8 +80,9 @@ class CurrencyEditorViewController: UIViewController {
         }
         
         guard !(budgetTextField.text!.isEmpty) else {
-            UIAlertController.oneButtonAlert(target: self, title: "저장 실패", message: "예산을 입력해주세요.")
-            return false
+            //UIAlertController.oneButtonAlert(target: self, title: "저장 실패", message: "예산을 입력해주세요.")
+            editedCurrency.budget = 0.0
+            return true
         }
         return true
     }
@@ -180,7 +181,7 @@ extension CurrencyEditorViewController: CurrencySelectTableViewControllerDelegat
                 
                 self.editedCurrency.code = code
                 
-                if let rateString = rate, let rate = Double(rateString) {
+                if let rate = rate {
                     self.editedCurrency.rate = rate
                     
                     let updatedAt = Date()
@@ -211,23 +212,21 @@ extension CurrencyEditorViewController: CurrencySelectTableViewControllerDelegat
         }
     }
     
-    func exchangeRateFromAPI(standard: String, compare: String, completion: @escaping (String?) -> Void) {
+    func exchangeRateFromAPI(standard: String, compare: String, completion: @escaping (Double?) -> Void) {
         
-        let url = URL(string: "https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20yahoo.finance.xchange%20where%20pair%20in%20(%22\(compare)\(standard)%22)&format=json&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys")!
+        let query = "\(compare)_\(standard)"
+        let url = URL(string: "https://free.currencyconverterapi.com/api/v3/convert?q=\(query)&compact=ultra")!
         
         let request = URLRequest(url: url, timeoutInterval: 10.0)
         
         let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
             let jsonData = try? JSONSerialization.jsonObject(with: data!, options: [])
             
-            var exchangeRate: String? = nil
+            var exchangeRate: Double? = nil
             
-            if let jsonObject = jsonData as? [String: Any],
-                let query = jsonObject["query"] as? [String: Any],
-                let results = query["results"] as? [String: Any],
-                let result = results["rate"] as? [String: String],
-                let rate = result["Rate"] {
-                exchangeRate = rate
+            if let jsonObject = jsonData as? [String: Double],
+                let val = jsonObject[query] {
+                exchangeRate = val
             }
             
             completion(exchangeRate)


### PR DESCRIPTION
- 잦은 오류로 Yahoo Finance API에서 The Free Currency Converter API로의 변경 #134 
- 통화 -> 통화 및 예산으로 관련 페이지 문구 변경
- 사용자가 예산을 입력하지 않고 넘어갈 경우 현재는 Alert가 뜨지만 자동으로 0원을 입력해주는 방식으로 변경