### PR TITLE
다중 Image 저장 시 비동기 처리

### DIFF
--- a/Project/PayRoad/AppDelegate.swift
+++ b/Project/PayRoad/AppDelegate.swift
@@ -26,7 +26,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         print(Realm.Configuration.defaultConfiguration.fileURL!)
-        
         RealmInitializer.initializeCategories()
 
         //UINavigationBar customize
@@ -60,7 +59,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        if SaveProcessing.shared.isSaving {
+            for item in SaveProcessing.shared.completedModels {
+                PhotoUtil.deletePhoto(filePath: item.filePath)
+            }
+        }
     }
     
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {

--- a/Project/PayRoad/Transaction.swift
+++ b/Project/PayRoad/Transaction.swift
@@ -34,7 +34,7 @@ class Transaction: Object {
         }
     }
     
-    let photos = List<Photo>()
+    var photos = List<Photo>()
     let travel = LinkingObjects(fromType: Travel.self, property: "transactions")
     
     override static func primaryKey() -> String? {

--- a/Project/PayRoad/TransactionDetailViewController.swift
+++ b/Project/PayRoad/TransactionDetailViewController.swift
@@ -65,12 +65,12 @@ class TransactionDetailViewController: UIViewController {
         collectionView.register(nibCell, forCellWithReuseIdentifier: "transactionCollectionViewCell")
         
         applyUIFromTransaction()
-        
+        imageViewConstraint.constant = transaction.photos.isEmpty ? 0 : 190
+
         mapView.delegate = self
         createMapView()
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: "reloadTransactionTableView"), object: self.transaction.id)
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(applyUIFromTransaction), name: NSNotification.Name(rawValue: "didSavedPhoto"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshImageViewer), name: NSNotification.Name(rawValue: "didSavedPhoto"), object: nil)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -116,7 +116,16 @@ class TransactionDetailViewController: UIViewController {
         
         descTextView.placeholder = transaction.content.isEmpty ? "기록된 내용이 없습니다." : nil
         descTextView.text = transaction.content
-        imageViewConstraint.constant = transaction.photos.isEmpty ? 0 : 190
+    }
+    
+    func refreshImageViewer(_ notification: Notification) {
+        let photos = notification.object as! List<Photo>
+        transaction.photos = photos
+        collectionView.reloadData()
+        UIView.animate(withDuration: 0.3, animations: {
+            self.imageViewConstraint.constant = self.transaction.photos.isEmpty ? 0 : 190
+            self.view.layoutIfNeeded()
+        })
     }
     
     @IBAction func editorButtonDidTap(_ sender: Any) {
@@ -211,7 +220,6 @@ extension TransactionDetailViewController: TransactionEditorDelegate {
         applyUIFromTransaction()
         mapView.clear()
         createMapView()
-        collectionView.reloadData()
     }
 }
 


### PR DESCRIPTION
* 비동기 처리
* 선택한 이미지 저장이 모두 완료된 후 모델이 반환되게 처리 -> 반환 후 모델 Transaction에 저장
* 만약 Image저장 도중 앱이 종료될 경우 Sandbox에 저장된 이미지 삭제 및 모델 반영 안함
* 비동기 저장 완료 후 Image가 보여야 하는 곳에서 reloadData 호출
close #146 